### PR TITLE
modify for bundler&travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ test/tmp
 test/version_tmp
 tmp
 
+# bundler
+vendor/
+
 # YARD artifacts
 .yardoc
 _yardoc
@@ -24,3 +27,6 @@ doc/
 # editor
 *~
 .redcar
+
+# other
+*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - ruby-head
+  - 1.9.3
+  - 1.9.2
+  - jruby-head
+  - jruby-19mode # JRuby in 1.9 mode
+  - rbx-19mode # Rubinius in 1.9 mode

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+gemspec
+
+group :development do
+  gem 'rake'
+  gem 'yard', '~>0.8.2.1'
+end
+
+group :test do
+  gem 'rake'
+end

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -3,6 +3,8 @@ LICENSE
 History.rdoc
 Manifest.txt
 Rakefile
+Gemfile
+validation.gemspec
 lib/validation.rb
 lib/validation/version.rb
 lib/validation/errors.rb

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,8 +1,5 @@
 = Validation
 
-code :: https://github.com/kachick/validation
-bugs :: https://github.com/kachick/validation/issues
-
 == Description
 
 A way of defining validations anywhere.
@@ -37,6 +34,14 @@ A way of defining validations anywhere.
 == Installation
 
     gem install validation
+
+== Links
+
+code   :: https://github.com/kachick/validation
+issues :: https://github.com/kachick/validation/issues
+CI     :: http://travis-ci.org/#!/kachick/validation
+gem    :: https://rubygems.org/gems/validation
+gem+   :: http://metagem.info/gems/validation
 
 == License
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,11 @@
-require 'rubygems'
-gem 'hoe', '~> 3.0.7'
-require 'hoe'
-require 'fileutils'
+#!/usr/bin/env rake
+require 'bundler/gem_tasks'
 
-Hoe.plugin :newgem
+require 'rake/testtask'
 
-# Generate all the Rake tasks
-# Run 'rake -T' to see list of generated tasks (from gem root directory)
-$hoe = Hoe.spec 'validation' do
-  developer 'Kenichi Kamiya', 'kachick1+ruby@gmail.com'
-  self.rubyforge_name       = self.name
-  require_ruby_version '>= 1.9.2'
-  dependency 'yard', '~> 0.8.2.1', :development
+task default: [:test]
+
+Rake::TestTask.new do |tt|
+  tt.verbose = true
 end
 
-require 'newgem/tasks'
-Dir['tasks/**/*.rake'].each { |t| load t }

--- a/validation.gemspec
+++ b/validation.gemspec
@@ -1,0 +1,22 @@
+# I don't know why dose occur errors below.
+#  require_relative 'lib/validation/version'
+require File.expand_path('../lib/validation/version', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ['Kenichi Kamiya']
+  gem.email         = ['kachick1+ruby@gmail.com']
+  gem.description   = %q{A way of defining validations anywhere.}
+  gem.summary       = %q{A way of defining validations anywhere.}
+  gem.homepage      = 'https://github.com/kachick/validation'
+
+  gem.files         = `git ls-files`.split($\)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features|declare)/})
+  gem.name          = 'validation'
+  gem.require_paths = ['lib']
+  gem.version       = Validation::VERSION.dup # dup for https://github.com/rubygems/rubygems/commit/48f1d869510dcd325d6566df7d0147a086905380#-P0
+
+  gem.required_ruby_version = '>= 1.9.2'
+  gem.add_development_dependency 'yard', '~> 0.8.2.1'
+end
+


### PR DESCRIPTION
http://travis-ci.org/#!/kachick/validation/builds/2181293

JRubyの失敗は、これ由来

https://github.com/jruby/jruby/pull/261
https://github.com/jruby/jruby/issues/265

ruby 1.9.2p320 (2012-04-20 revision 35421) [i686-linux]
についてはまだ調べてない。
手元のリリース版、ruby 1.9.2p290 (2011-07-09) [i386-mingw32]だと通る
